### PR TITLE
feat/VLWA-1711-web-change-validators-backend-url-for-mainnet

### DIFF
--- a/plugins/sol-coin.js
+++ b/plugins/sol-coin.js
@@ -16,7 +16,7 @@
       web3Provider: 'https://api.velas.com',
       url: 'https://native.velas.com',
       apiUrl: 'https://api.velas.com',
-      validatorsBackend: 'https://validators.devnet.velas.com'
+      validatorsBackend: 'https://validators.mainnet.velas.com',
     },
     HomeBridge: "0x56454c41532d434841494e000000000053574150",
     networks: {


### PR DESCRIPTION
changed  validators mainnet
- from `https://validators.devnet.velas.com` to `https://validators.mainnet.velas.com`

<!-- Replace -->
[VLWA-1711](https://velasnetwork.atlassian.net/browse/VLWA-1711) – [web] change validators backend url for mainnet
<!-- Replace -->
