### PR TITLE
fix/VLWA-1791-clone-delegate-stake-tx-on-velas-native-doesnt-show-to-and-from-when-click-on-tx

### DIFF
--- a/providers/solana.js
+++ b/providers/solana.js
@@ -563,10 +563,21 @@ const commonProvider = require('./common/provider');
             amount = (ref$ = getSentAmount(txData)[sender]) != null ? ref$ : 0;
           }
           if (type === "delegate") {
-            sender = instructions[0].parsed.info.stakeAccount;
-            receiver = instructions[0].parsed.info.voteAccount;
+            const delegateInstruction = instructions.find(
+              (instruction) => instruction.parsed.type === 'delegate'
+            );
+
+            if (!delegateInstruction) {
+              console.error(
+                `[solana] prepareTxs hash ${transaction.signatures[0]} type ${type} no delegateInstruction found!`
+              );
+            }
+
+            sender = delegateInstruction.parsed.info.stakeAccount;
+            receiver = delegateInstruction.parsed.info.voteAccount;
             hash = transaction.signatures[0];
-            amount = instructions[0].parsed.info.lamports;
+            amount =
+            (ref2$ = getSentAmount(txData)[sender]) != null ? ref2$ : 0;
           }
           if (type === "createAccountWithSeed") {
             sender = instructions[0].parsed.info.base;
@@ -575,8 +586,17 @@ const commonProvider = require('./common/provider');
             hash = transaction.signatures[0];
           }
           if (type === "deactivate") {
-            sender = instructions[0].parsed.info.stakeAuthority;
-            receiver = instructions[0].programId;
+            const deactivateInstruction = instructions.find(
+              (instruction) => instruction.parsed.type === 'deactivate'
+            );
+
+            if (!deactivateInstruction) {
+              console.error(
+                `[solana] prepareTxs hash ${transaction.signatures[0]} type ${type} no deactivateInstruction found!`
+              );
+            }
+            sender = deactivateInstruction.parsed.info.stakeAuthority;
+            receiver = deactivateInstruction.programId;
             hash = transaction.signatures[0];
             amount = 0;
           }


### PR DESCRIPTION
get delegate and deactivate instruction handling
- in `web3/providers/solana.js` [getTxData]

<!-- Replace -->
[VLWA-1791](https://velasnetwork.atlassian.net/browse/VLWA-1791) – Delegate stake tx on velas native doesnt show to and from when click on tx
<!-- Replace -->
